### PR TITLE
Fix Netlify build error in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,8 +26,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      'node-fetch': 'isomorphic-fetch',
-      'react-dom': 'react-dom/client'
+      'node-fetch': 'isomorphic-fetch'
     }
   },
   define: { 


### PR DESCRIPTION
## Summary
- update `vite.config.ts` to stop aliasing `react-dom` to `react-dom/client`

## Testing
- `npm test`
- `npm run build`
