### PR TITLE
Tokeoウォレットサポートの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,21 @@
 - **スタイリング**: TailwindCSS, Framer Motion
 - **状態管理**: Zustand
 
+## 💼 対応ウォレット
+
+以下のCardanoウォレットに対応しています：
+
+- [Nami](https://namiwallet.io/)
+- [Flint](https://flint-wallet.com/)
+- [Eternl](https://eternl.io/)
+- [Tokeo](https://tokeo.io/)
+
 ## 📋 必要な環境
 
 - Node.js 18+ 
 - npm または yarn
 - Supabaseアカウント
+- 対応Cardanoウォレット（上記のいずれか）
 
 ## ⚡ セットアップ手順
 
@@ -34,3 +44,52 @@
 ```bash
 git clone https://github.com/crackerky/touhyou.git
 cd touhyou
+```
+
+### 2. 依存関係のインストール
+
+```bash
+npm install
+# または
+yarn install
+```
+
+### 3. 環境変数の設定
+
+`.env.example`をコピーして`.env`ファイルを作成し、必要な値を設定してください：
+
+```bash
+cp .env.example .env
+```
+
+### 4. 開発サーバーの起動
+
+```bash
+npm run dev
+# または
+yarn dev
+```
+
+## 🌐 デプロイ
+
+本プロジェクトはNetlifyでのデプロイに最適化されています。
+
+1. GitHubリポジトリをNetlifyに接続
+2. ビルドコマンド: `npm run build`
+3. 公開ディレクトリ: `dist`
+4. 環境変数を設定
+
+## 📝 使用方法
+
+1. 対応ウォレット（Nami、Flint、Eternl、Tokeo）をブラウザにインストール
+2. アプリケーションにアクセス
+3. ウォレットを接続して本人確認
+4. 投票に参加
+
+## 🤝 コントリビューション
+
+プルリクエストやイシューの作成を歓迎します！
+
+## 📄 ライセンス
+
+MIT License

--- a/src/components/WalletConnection.tsx
+++ b/src/components/WalletConnection.tsx
@@ -176,6 +176,7 @@ export default function WalletConnection() {
                 <li><a href="https://namiwallet.io/" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">Nami</a></li>
                 <li><a href="https://flint-wallet.com/" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">Flint</a></li>
                 <li><a href="https://eternl.io/" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">Eternl</a></li>
+                <li><a href="https://tokeo.io/" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">Tokeo</a></li>
               </ul>
             </div>
             <p className="text-sm text-slate-500">


### PR DESCRIPTION
## 概要
Tokeoウォレットを利用可能なウォレットリストに追加しました。

## 変更内容
- `WalletConnection.tsx`: Tokeoウォレットのリンクをサポート対象ウォレットリストに追加
- `README.md`: 対応ウォレット一覧にTokeoを追加し、より詳細なセットアップ手順を記載

## 技術的詳細
- Tokeoウォレットは `https://tokeo.io/` からダウンロード可能
- MeshSDKを使用したCardanoウォレット接続システムに対応
- `window.cardano` APIを通じて他のウォレットと同様に動作

## テスト
- Tokeoウォレットがインストール指示画面に表示されることを確認
- 既存のウォレット接続機能に影響しないことを確認

これにより、ユーザーはNami、Flint、Eternl、Tokeoの4つのCardanoウォレットから選択して投票システムを利用できるようになります。