### PR TITLE
スマホタブにTokeo Mobileを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - [Yoroi Wallet](https://yoroi-wallet.com/) - iOS/Android
 - [Nami Mobile](https://namiwallet.io/) - モバイルブラウザ
 - [Eternl Mobile](https://eternl.io/) - iOS/Android
+- [Tokeo Mobile](https://tokeo.io/) - モバイル対応
 
 ### ✍️ 手動アドレス入力の手順
 
@@ -119,7 +120,11 @@ yarn dev
 3. 投票に参加
 
 ### スマホユーザー
-1. Cardanoウォレットアプリをダウンロード
+1. Cardanoウォレットアプリをダウンロード：
+   - Yoroi Wallet
+   - Nami Mobile  
+   - Eternl Mobile
+   - Tokeo Mobile
 2. ウォレットを作成してアドレスを取得
 3. 「手動入力」タブでアドレスを入力
 4. 投票に参加

--- a/src/components/WalletConnection.tsx
+++ b/src/components/WalletConnection.tsx
@@ -365,6 +365,11 @@ export default function WalletConnection() {
                           📱 Eternl Mobile
                         </a>
                       </li>
+                      <li>
+                        <a href="https://tokeo.io/" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline font-medium">
+                          📱 Tokeo Mobile
+                        </a>
+                      </li>
                     </ul>
                   </div>
                   <Button 


### PR DESCRIPTION
## 概要
スマホタブにTokeo Mobileを追加し、モバイルユーザーの選択肢を拡大しました。

## 🚀 変更内容

### スマホアプリ対応の拡張
- **Tokeo Mobile**をスマホタブのウォレットリストに追加
- モバイルユーザーが利用できるウォレットオプションを4つに拡大

### 更新されたモバイルウォレット一覧
1. **Yoroi Wallet** - iOS/Android
2. **Nami Mobile** - モバイルブラウザ  
3. **Eternl Mobile** - iOS/Android
4. **Tokeo Mobile** - モバイル対応 ← **新規追加**

### ドキュメント更新
- README.mdでTokeo Mobileをサポート対象として明記
- スマホユーザー向けの手順説明を更新

## 🎯 ユーザーへの影響

- **選択肢の拡大**: スマホユーザーが4つのウォレットから選択可能
- **アクセシビリティ向上**: Tokeoユーザーもモバイルから簡単にアクセス
- **NFT配布効率化**: より多くのユーザーからアドレス収集が可能

## 📱 利用方法

### スマホユーザー
1. **スマホタブ**を選択
2. Tokeo Mobileアプリをダウンロード
3. **手動入力タブ**でアドレスを入力して投票参加

これにより、Tokeoウォレットユーザーも拡張機能だけでなく、モバイル環境からも投票システムにアクセスできるようになります。